### PR TITLE
docs: add docs directory for canonical package documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Authentication and authorization module for the Bunary framework. Provides a flexible guard-based authentication system.
 
+## Documentation
+
+Canonical documentation for this package lives in [`docs/index.md`](./docs/index.md).
+
 ## Installation
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,35 @@
+# @bunary/auth
+
+Authentication primitives and guards for Bunary.
+
+## Installation
+
+```bash
+bun add @bunary/auth
+```
+
+## Quickstart (minimal)
+
+This package provides authentication building blocks. A request-safe, app-scoped integration API is being tracked separately (see the auth roadmap).
+
+```ts
+import { createAuthManager } from "@bunary/auth";
+
+const manager = createAuthManager({
+  defaultGuard: "example",
+  guards: {
+    example: {
+      name: "example",
+      async authenticate(request) {
+        const token = request.headers.get("Authorization");
+        return token ? { id: "1" } : null;
+      },
+    },
+  },
+});
+```
+
+## Requirements
+
+- Bun ≥ 1.0.0
+


### PR DESCRIPTION
## Summary
- Add `docs/index.md` as the canonical documentation entry for `@bunary/auth`.
- Update the README to point to the `docs/` directory.

## Test plan
- N/A (documentation only)

Closes #18