### PR TITLE
feat: request-scoped AuthContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.3] - 2026-01-28
+
+### Added
+
+- Request-scoped `AuthContext` via `manager.createContext({ request })` (no shared user state across concurrent requests)
+
+### Changed
+
+- `auth()` helper now requires a request input: `auth({ request })` and returns an `AuthContext`
+- `AuthManagerInterface` is now stateless and no longer stores a global/current user
+
 ## [0.0.1] - 2025-01-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ bun add @bunary/auth
 
 ## Quick Start
 
-```typescript
+```ts
 import { createAuthManager, setAuthManager, auth } from "@bunary/auth";
-import type { Guard, AuthUser } from "@bunary/auth";
+import type { Guard } from "@bunary/auth";
 
 // Define a JWT guard
 const jwtGuard: Guard = {
@@ -31,16 +31,23 @@ const jwtGuard: Guard = {
   }
 };
 
-// Create and register the auth manager
-const authManager = createAuthManager({
+// Create the auth manager (stateless) with your guards
+const manager = createAuthManager({
   defaultGuard: "jwt",
-  guards: [jwtGuard]
+  guards: { jwt: jwtGuard }
 });
 
-setAuthManager(authManager);
+// Optional: set a global manager to use the `auth({ request })` helper
+setAuthManager(manager);
 
 // Use in your application
-const user = await auth();
+const request = new Request("http://localhost/profile", {
+  headers: { Authorization: "Bearer my-token" },
+});
+
+const authCtx = auth({ request });
+await authCtx.authenticate(); // uses default guard
+const user = authCtx.user();
 ```
 
 ## API
@@ -49,16 +56,16 @@ const user = await auth();
 
 Creates a new authentication manager instance.
 
-```typescript
+```ts
 const manager = createAuthManager({
   defaultGuard: "jwt",
-  guards: [jwtGuard, sessionGuard]
+  guards: { jwt: jwtGuard },
 });
 ```
 
 **Config Options:**
 - `defaultGuard` - Name of the default guard to use
-- `guards` - Array of guard implementations
+- `guards` - Record of guard implementations (keyed by guard name)
 
 ### `setAuthManager(manager)`
 
@@ -68,18 +75,17 @@ Sets the global authentication manager instance.
 setAuthManager(manager);
 ```
 
-### `auth()`
+### `auth({ request })`
 
-Returns the currently authenticated user, or `null` if not authenticated.
+Creates a **request-scoped** auth context (requires `setAuthManager()` first).
 
-```typescript
-const user = auth();
-if (user) {
-  console.log(`Hello, ${user.name}`);
-}
+```ts
+const authCtx = auth({ request });
+await authCtx.authenticate();
+const user = authCtx.user();
 ```
 
-### AuthManager Methods
+### AuthManager methods
 
 #### `guard(name?)`
 
@@ -90,40 +96,22 @@ const jwt = manager.guard("jwt");
 const defaultGuard = manager.guard();
 ```
 
-#### `authenticate(request, guardName?)`
+#### `createContext({ request })`
 
-Authenticate a request using the specified guard (or default).
+Create a request-scoped auth context (safe under concurrency):
 
-```typescript
-const user = await manager.authenticate(request);
-const user = await manager.authenticate(request, "session");
+```ts
+const authCtx = manager.createContext({ request });
+await authCtx.authenticate(); // stores user on this context only
 ```
 
-#### `user()`
+### AuthContext methods
 
-Get the currently authenticated user.
-
-```typescript
-const user = manager.user();
-```
-
-#### `check()`
-
-Check if a user is authenticated.
-
-```typescript
-if (manager.check()) {
-  // User is authenticated
-}
-```
-
-#### `logout()`
-
-Clear the authenticated user.
-
-```typescript
-manager.logout();
-```
+- `authenticate(guardName?)`
+- `user()`
+- `check()`
+- `require()`
+- `logout()`
 
 ## Guard Interface
 
@@ -186,7 +174,7 @@ interface Guard {
 
 interface AuthConfig {
   defaultGuard: string;
-  guards: Guard[];
+  guards: Record<string, Guard>;
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,16 @@ const manager = createAuthManager({
     },
   },
 });
+cd ..
+// Per-request usage
+const auth = manager.createContext({
+  request: new Request("http://localhost/profile", {
+    headers: { Authorization: "Bearer anything" },
+  }),
+});
+
+await auth.authenticate();
+const user = auth.user();
 ```
 
 ## Requirements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/auth",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Authentication guards and helpers for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,7 +1,7 @@
 /**
  * Global auth helper functions for accessing authentication state.
  */
-import type { AuthManagerInterface, AuthUser } from "./types.js";
+import type { AuthContext, AuthManagerInterface, GuardInput } from "./types.js";
 
 let globalAuthManager: AuthManagerInterface | null = null;
 
@@ -25,29 +25,26 @@ export function setAuthManager(manager: AuthManagerInterface): void {
 }
 
 /**
- * Get the current authenticated user from the global auth manager.
+ * Create a request-scoped AuthContext using the global auth manager.
  *
- * @returns The authenticated user or null if not authenticated
+ * @param input - Request-scoped input for guards
+ * @returns A request-scoped auth context
  * @throws If no auth manager has been set
  *
  * @example
  * ```ts
- * app.get("/profile", () => {
- *   const user = auth();
- *   if (!user) {
- *     return new Response("Unauthorized", { status: 401 });
- *   }
- *   return { user };
- * });
+ * const ctx = auth({ request });
+ * await ctx.authenticate();
+ * return ctx.user();
  * ```
  */
-export function auth(): AuthUser | null {
+export function auth(input: GuardInput): AuthContext {
 	if (!globalAuthManager) {
 		throw new Error(
 			"Auth manager not initialized. Call setAuthManager() before using auth().",
 		);
 	}
-	return globalAuthManager.user();
+	return globalAuthManager.createContext(input);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,9 @@
  * setAuthManager(authManager);
  *
  * // In a route handler
- * const user = auth();
+ * const ctx = auth({ request });
+ * await ctx.authenticate();
+ * const user = ctx.user();
  * ```
  */
 
@@ -34,6 +36,8 @@ export type {
 	AuthUser,
 	Guard,
 	AuthConfig,
+	GuardInput,
+	AuthContext,
 	AuthManagerInterface,
 } from "./types.js";
 

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -28,11 +28,10 @@ import type {
 	AuthManagerInterface,
 	AuthUser,
 	Guard,
+	GuardInput,
 } from "./types.js";
 
 export function createAuthManager(config: AuthConfig): AuthManagerInterface {
-	let currentUser: AuthUser | null = null;
-
 	return {
 		/**
 		 * Get a guard by name.
@@ -53,45 +52,39 @@ export function createAuthManager(config: AuthConfig): AuthManagerInterface {
 		},
 
 		/**
-		 * Authenticate a request using the specified or default guard.
+		 * Create a request-scoped auth context.
 		 *
-		 * @param request - The incoming HTTP request
-		 * @param guardName - Optional guard name to use
-		 * @returns The authenticated user or null
+		 * The returned object holds per-request state (current user) and is safe
+		 * to use concurrently across multiple requests.
 		 */
-		async authenticate(
-			request: Request,
-			guardName?: string,
-		): Promise<AuthUser | null> {
-			const guard = this.guard(guardName);
-			const user = await guard.authenticate(request);
-			currentUser = user;
-			return user;
-		},
+		createContext(input: GuardInput) {
+			let currentUser: AuthUser | null = null;
 
-		/**
-		 * Get the currently authenticated user.
-		 *
-		 * @returns The authenticated user or null
-		 */
-		user(): AuthUser | null {
-			return currentUser;
-		},
+			return {
+				guard: (name?: string) => this.guard(name),
 
-		/**
-		 * Check if a user is currently authenticated.
-		 *
-		 * @returns true if authenticated, false otherwise
-		 */
-		check(): boolean {
-			return currentUser !== null;
-		},
+				authenticate: async (guardName?: string): Promise<AuthUser | null> => {
+					const guard = this.guard(guardName);
+					const user = await guard.authenticate(input.request);
+					currentUser = user;
+					return user;
+				},
 
-		/**
-		 * Clear the current authentication state.
-		 */
-		logout(): void {
-			currentUser = null;
+				user: (): AuthUser | null => currentUser,
+
+				check: (): boolean => currentUser !== null,
+
+				require: (): AuthUser => {
+					if (!currentUser) {
+						throw new Error("Unauthenticated");
+					}
+					return currentUser;
+				},
+
+				logout: (): void => {
+					currentUser = null;
+				},
+			};
 		},
 	};
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,57 @@ export interface AuthConfig {
 }
 
 /**
+ * Input passed to guards/auth contexts.
+ *
+ * Keep this minimal and explicit for MVP. Additional request-scoped fields
+ * (like params/query) can be added later without introducing global state.
+ */
+export interface GuardInput {
+	/** The incoming HTTP request */
+	request: Request;
+}
+
+/**
+ * Request-scoped authentication context.
+ *
+ * This holds **per-request** authentication state (the current user),
+ * and provides explicit methods for authentication.
+ */
+export interface AuthContext {
+	/**
+	 * Get a guard by name (or the default guard).
+	 */
+	guard(name?: string): Guard;
+
+	/**
+	 * Authenticate the request using the specified or default guard.
+	 *
+	 * Stores the user on this context (not globally).
+	 */
+	authenticate(guardName?: string): Promise<AuthUser | null>;
+
+	/**
+	 * Get the currently authenticated user for this request.
+	 */
+	user(): AuthUser | null;
+
+	/**
+	 * Returns true if the request is authenticated.
+	 */
+	check(): boolean;
+
+	/**
+	 * Get the authenticated user or throw.
+	 */
+	require(): AuthUser;
+
+	/**
+	 * Clear authentication state for this request.
+	 */
+	logout(): void;
+}
+
+/**
  * The AuthManager interface for managing authentication state.
  *
  * @example
@@ -86,9 +137,10 @@ export interface AuthConfig {
  * });
  *
  * // In a request handler
- * await authManager.authenticate(request);
- * if (authManager.check()) {
- *   const user = authManager.user();
+ * const auth = authManager.createContext({ request });
+ * await auth.authenticate();
+ * if (auth.check()) {
+ *   const user = auth.user();
  * }
  * ```
  */
@@ -103,30 +155,10 @@ export interface AuthManagerInterface {
 	guard(name?: string): Guard;
 
 	/**
-	 * Authenticate a request using the specified or default guard.
+	 * Create a request-scoped AuthContext.
 	 *
-	 * @param request - The incoming HTTP request
-	 * @param guardName - Optional guard name to use
-	 * @returns The authenticated user or null
+	 * @param input - Request-scoped input for guards
+	 * @returns A request-scoped auth context (isolated per request)
 	 */
-	authenticate(request: Request, guardName?: string): Promise<AuthUser | null>;
-
-	/**
-	 * Get the currently authenticated user.
-	 *
-	 * @returns The authenticated user or null
-	 */
-	user(): AuthUser | null;
-
-	/**
-	 * Check if a user is currently authenticated.
-	 *
-	 * @returns true if authenticated, false otherwise
-	 */
-	check(): boolean;
-
-	/**
-	 * Clear the current authentication state.
-	 */
-	logout(): void;
+	createContext(input: GuardInput): AuthContext;
 }

--- a/tests/helpers.test.ts
+++ b/tests/helpers.test.ts
@@ -38,17 +38,21 @@ describe("auth() helper", () => {
 
 	describe("auth()", () => {
 		test("throws when no auth manager is set", () => {
-			expect(() => auth()).toThrow();
+			expect(() =>
+				auth({ request: new Request("http://localhost/test") }),
+			).toThrow();
 		});
 
-		test("returns null when not authenticated", () => {
+		test("creates a context (unauthenticated by default)", () => {
 			const authManager = createAuthManager({
 				defaultGuard: "test",
 				guards: { test: mockGuard },
 			});
 			setAuthManager(authManager);
 
-			expect(auth()).toBeNull();
+			const ctx = auth({ request: new Request("http://localhost/test") });
+			expect(ctx.user()).toBeNull();
+			expect(ctx.check()).toBe(false);
 		});
 
 		test("returns user after authentication", async () => {
@@ -61,9 +65,10 @@ describe("auth() helper", () => {
 			const request = new Request("http://localhost/test", {
 				headers: { Authorization: "Bearer valid" },
 			});
-			await authManager.authenticate(request);
+			const ctx = auth({ request });
+			await ctx.authenticate();
 
-			expect(auth()).toEqual({ id: 1, name: "Test User" });
+			expect(ctx.user()).toEqual({ id: 1, name: "Test User" });
 		});
 
 		test("returns null after logout", async () => {
@@ -76,10 +81,11 @@ describe("auth() helper", () => {
 			const request = new Request("http://localhost/test", {
 				headers: { Authorization: "Bearer valid" },
 			});
-			await authManager.authenticate(request);
-			authManager.logout();
+			const ctx = auth({ request });
+			await ctx.authenticate();
+			ctx.logout();
 
-			expect(auth()).toBeNull();
+			expect(ctx.user()).toBeNull();
 		});
 	});
 

--- a/tests/manager.test.ts
+++ b/tests/manager.test.ts
@@ -41,10 +41,7 @@ describe("AuthManager", () => {
 			const authManager = createAuthManager(createConfig());
 			expect(authManager).toBeDefined();
 			expect(typeof authManager.guard).toBe("function");
-			expect(typeof authManager.authenticate).toBe("function");
-			expect(typeof authManager.user).toBe("function");
-			expect(typeof authManager.check).toBe("function");
-			expect(typeof authManager.logout).toBe("function");
+			expect(typeof authManager.createContext).toBe("function");
 		});
 	});
 
@@ -67,14 +64,15 @@ describe("AuthManager", () => {
 		});
 	});
 
-	describe("authenticate()", () => {
+	describe("AuthContext", () => {
 		test("authenticates valid request with default guard", async () => {
 			const authManager = createAuthManager(createConfig());
 			const request = new Request("http://localhost/test", {
 				headers: { Authorization: "Bearer valid-token" },
 			});
 
-			const user = await authManager.authenticate(request);
+			const ctx = authManager.createContext({ request });
+			const user = await ctx.authenticate();
 			expect(user).toEqual({
 				id: 1,
 				name: "John Doe",
@@ -88,7 +86,8 @@ describe("AuthManager", () => {
 				headers: { Authorization: "Bearer invalid-token" },
 			});
 
-			const user = await authManager.authenticate(request);
+			const ctx = authManager.createContext({ request });
+			const user = await ctx.authenticate();
 			expect(user).toBeNull();
 		});
 
@@ -98,29 +97,32 @@ describe("AuthManager", () => {
 				headers: { "X-API-Key": "test-key" },
 			});
 
-			const user = await authManager.authenticate(request, "api-key");
+			const ctx = authManager.createContext({ request });
+			const user = await ctx.authenticate("api-key");
 			expect(user).toEqual({ id: 2, name: "API User" });
 		});
 
-		test("stores authenticated user for later retrieval", async () => {
+		test("stores authenticated user on the context for later retrieval", async () => {
 			const authManager = createAuthManager(createConfig());
 			const request = new Request("http://localhost/test", {
 				headers: { Authorization: "Bearer valid-token" },
 			});
 
-			await authManager.authenticate(request);
-			expect(authManager.user()).toEqual({
+			const ctx = authManager.createContext({ request });
+			await ctx.authenticate();
+			expect(ctx.user()).toEqual({
 				id: 1,
 				name: "John Doe",
 				email: "john@example.com",
 			});
 		});
-	});
 
-	describe("user()", () => {
 		test("returns null before authentication", () => {
 			const authManager = createAuthManager(createConfig());
-			expect(authManager.user()).toBeNull();
+			const ctx = authManager.createContext({
+				request: new Request("http://localhost/test"),
+			});
+			expect(ctx.user()).toBeNull();
 		});
 
 		test("returns authenticated user after authentication", async () => {
@@ -129,55 +131,108 @@ describe("AuthManager", () => {
 				headers: { Authorization: "Bearer valid-token" },
 			});
 
-			await authManager.authenticate(request);
-			expect(authManager.user()).toEqual({
+			const ctx = authManager.createContext({ request });
+			await ctx.authenticate();
+			expect(ctx.user()).toEqual({
 				id: 1,
 				name: "John Doe",
 				email: "john@example.com",
 			});
 		});
-	});
 
-	describe("check()", () => {
-		test("returns false before authentication", () => {
+		test("check() returns false before authentication", () => {
 			const authManager = createAuthManager(createConfig());
-			expect(authManager.check()).toBe(false);
+			const ctx = authManager.createContext({
+				request: new Request("http://localhost/test"),
+			});
+			expect(ctx.check()).toBe(false);
 		});
 
-		test("returns true after successful authentication", async () => {
+		test("check() returns true after successful authentication", async () => {
 			const authManager = createAuthManager(createConfig());
 			const request = new Request("http://localhost/test", {
 				headers: { Authorization: "Bearer valid-token" },
 			});
 
-			await authManager.authenticate(request);
-			expect(authManager.check()).toBe(true);
+			const ctx = authManager.createContext({ request });
+			await ctx.authenticate();
+			expect(ctx.check()).toBe(true);
 		});
 
-		test("returns false after failed authentication", async () => {
+		test("check() returns false after failed authentication", async () => {
 			const authManager = createAuthManager(createConfig());
 			const request = new Request("http://localhost/test", {
 				headers: { Authorization: "Bearer invalid-token" },
 			});
 
-			await authManager.authenticate(request);
-			expect(authManager.check()).toBe(false);
+			const ctx = authManager.createContext({ request });
+			await ctx.authenticate();
+			expect(ctx.check()).toBe(false);
 		});
-	});
 
-	describe("logout()", () => {
-		test("clears the authenticated user", async () => {
+		test("logout() clears the authenticated user", async () => {
 			const authManager = createAuthManager(createConfig());
 			const request = new Request("http://localhost/test", {
 				headers: { Authorization: "Bearer valid-token" },
 			});
 
-			await authManager.authenticate(request);
-			expect(authManager.check()).toBe(true);
+			const ctx = authManager.createContext({ request });
+			await ctx.authenticate();
+			expect(ctx.check()).toBe(true);
 
-			authManager.logout();
-			expect(authManager.check()).toBe(false);
-			expect(authManager.user()).toBeNull();
+			ctx.logout();
+			expect(ctx.check()).toBe(false);
+			expect(ctx.user()).toBeNull();
+		});
+
+		test("require() throws when unauthenticated", () => {
+			const authManager = createAuthManager(createConfig());
+			const ctx = authManager.createContext({
+				request: new Request("http://localhost/test"),
+			});
+			expect(() => ctx.require()).toThrow("Unauthenticated");
+		});
+
+		test("require() returns the user when authenticated", async () => {
+			const authManager = createAuthManager(createConfig());
+			const ctx = authManager.createContext({
+				request: new Request("http://localhost/test", {
+					headers: { Authorization: "Bearer valid-token" },
+				}),
+			});
+			await ctx.authenticate();
+			expect(ctx.require()).toEqual({
+				id: 1,
+				name: "John Doe",
+				email: "john@example.com",
+			});
+		});
+
+		test("contexts are isolated (no user leakage across concurrent requests)", async () => {
+			const authManager = createAuthManager(createConfig());
+
+			const ctxA = authManager.createContext({
+				request: new Request("http://localhost/test", {
+					headers: { Authorization: "Bearer valid-token" },
+				}),
+			});
+			const ctxB = authManager.createContext({
+				request: new Request("http://localhost/test", {
+					headers: { "X-API-Key": "test-key" },
+				}),
+			});
+
+			await Promise.all([
+				ctxA.authenticate("jwt"),
+				ctxB.authenticate("api-key"),
+			]);
+
+			expect(ctxA.user()).toEqual({
+				id: 1,
+				name: "John Doe",
+				email: "john@example.com",
+			});
+			expect(ctxB.user()).toEqual({ id: 2, name: "API User" });
 		});
 	});
 });
@@ -204,7 +259,8 @@ describe("Guard Interface", () => {
 			headers: { Authorization: "Bearer sync-token" },
 		});
 
-		const user = await authManager.authenticate(request);
+		const ctx = authManager.createContext({ request });
+		const user = await ctx.authenticate();
 		expect(user).toEqual({ id: 3, name: "Sync User" });
 	});
 });


### PR DESCRIPTION
## Summary
- Adds a request-scoped `AuthContext` created via `manager.createContext({ request })`.
- Removes shared `currentUser` state from the AuthManager (contexts are isolated per request).
- Updates the global `auth()` helper to `auth({ request })` (returns an `AuthContext`).

## Tests
- Adds unit tests for context isolation, authenticate/user, and logout.

## Version
- Bumps `@bunary/auth` to `0.0.3` and updates `CHANGELOG.md`.

Closes #14