### PR TITLE
chore: remove unused @bunary/core dependency (Closes #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First-party auth guards tracker (feature #10): Both Basic Auth and JWT Bearer guards are now available as documented factory functions with complete README examples
 
+### Removed
+
+- Unused dependency on `@bunary/core` (chore #13): The package had no imports from `@bunary/core`, so the dependency was removed to reduce install footprint
+
 ## [0.0.5] - 2026-01-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -45,9 +45,7 @@
   "engines": {
     "bun": ">=1.0.0"
   },
-  "dependencies": {
-    "@bunary/core": "0.0.5"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@biomejs/biome": "2.3.13",
     "@types/bun": "1.3.7",


### PR DESCRIPTION
This PR removes the unused dependency on `@bunary/core` from `@bunary/auth`.

## Problem
`@bunary/auth` listed `@bunary/core` as a dependency but the codebase does not import it anywhere. This increases install footprint and can confuse consumers.

## Changes
- Removed `@bunary/core` from dependencies in `package.json`
- Updated CHANGELOG.md to document the removal

## Verification
- ✅ Searched entire codebase: no imports from `@bunary/core` found
- ✅ All 79 tests pass
- ✅ Linting passes
- ✅ Type checking passes
- ✅ Package installs successfully without the dependency

## Impact
- Reduces install footprint
- Removes confusion about unused dependencies
- No breaking changes (dependency was never used)

Closes #13