### PR TITLE
chore: remove unnecessary Biome override for src/index.ts (Closes #28)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,17 +11,5 @@
 		"enabled": true,
 		"indentStyle": "tab",
 		"indentWidth": 2
-	},
-	"overrides": [
-		{
-			"includes": ["src/index.ts"],
-			"assist": {
-				"actions": {
-					"source": {
-						"organizeImports": "off"
-					}
-				}
-			}
-		}
-	]
+	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,42 +36,36 @@
  * ```
  */
 
-// Types
-export type {
-	AuthUser,
-	Guard,
-	AuthConfig,
-	AuthStorage,
-	GuardInput,
-	AuthContext,
-	AuthManagerInterface,
-	InstallableAuthManager,
-	AuthPlugin,
-	AuthPluginRouter,
-} from "./types.js";
-
-// Auth Manager
-export { createAuthManager } from "./manager.js";
-
 // App-scoped integration
 export { createAuth } from "./appScoped.js";
-
+export type { BasicGuardOptions } from "./guards/basic.js";
+export { createBasicGuard } from "./guards/basic.js";
+export type { JwtGuardOptions } from "./guards/jwt.js";
+// Guards
+export { createJwtGuard } from "./guards/jwt.js";
 // Helpers
 export {
 	auth,
-	setAuthManager,
-	getAuthManager,
 	clearAuthManager,
+	getAuthManager,
+	setAuthManager,
 } from "./helpers.js";
-
-// Storage
-export { createCookieStorage } from "./storage.js";
-
-// Guards
-export { createJwtGuard } from "./guards/jwt.js";
-export type { JwtGuardOptions } from "./guards/jwt.js";
-export { createBasicGuard } from "./guards/basic.js";
-export type { BasicGuardOptions } from "./guards/basic.js";
-
+// Auth Manager
+export { createAuthManager } from "./manager.js";
 // Plugins
 export { installAuthPlugin } from "./plugin.js";
+// Storage
+export { createCookieStorage } from "./storage.js";
+// Types
+export type {
+	AuthConfig,
+	AuthContext,
+	AuthManagerInterface,
+	AuthPlugin,
+	AuthPluginRouter,
+	AuthStorage,
+	AuthUser,
+	Guard,
+	GuardInput,
+	InstallableAuthManager,
+} from "./types.js";


### PR DESCRIPTION
This PR removes the Biome override that disabled import organization for `src/index.ts`.

## Problem
The override was disabling `organizeImports` for `src/index.ts`, which prevented Biome from checking import organization. While the override preserved logical grouping (Types, Auth Manager, etc.), it was hiding a lint check.

## Solution
- Removed the override from `biome.json`
- Let Biome organize exports alphabetically
- All linting and type checking passes

## Trade-offs
- ✅ Biome can now check import organization
- ✅ Consistent with other files in the codebase
- ⚠️ Exports are now alphabetical instead of logically grouped

If logical grouping is preferred, we can add the override back with documentation explaining why it's needed.

Closes #28