### PR TITLE
docs: README vs docs/index.md separation (documentation #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @bunary/auth
 
-Authentication and authorization for the Bunary framework. Guard-based: createAuth (app-scoped with @bunary/http), createAuthManager, built-in JWT and Basic guards, AuthStorage for cookies, AuthPlugin for third-party providers. Full reference: [docs/index.md](./docs/index.md).
+Authentication and authorization for the Bunary framework. Provides a guard-based authentication system with createAuth for app-scoped integration with @bunary/http, createAuthManager for standalone use, built-in JWT and Basic guards, AuthStorage for cookie management, and AuthPlugin support for third-party providers. See full reference: [docs/index.md](./docs/index.md).
 
 ## Installation
 
@@ -8,7 +8,7 @@ Authentication and authorization for the Bunary framework. Guard-based: createAu
 bun add @bunary/auth
 ```
 
-## Quick start
+## Quick Start
 
 ```ts
 import { createAuth, createJwtGuard } from "@bunary/auth";

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,8 +21,8 @@ const jwtGuard: Guard = {
     const token = request.headers.get("Authorization")?.replace("Bearer ", "");
     if (!token) return null;
 
-    // Validate token and return user
-    const user = await validateToken(token);
+    // Your token validation logic here (e.g. verify JWT, decode, return user or null)
+    const user = null; // replace with your verifyToken(token) or similar
     return user;
   }
 };
@@ -73,7 +73,7 @@ const authMiddleware = createAuth({
 app.use(authMiddleware);
 
 // Access auth in route handlers via ctx.locals.auth
-app.get("/profile", (ctx) => {
+app.get("/profile", async (ctx) => {
   const auth = ctx.locals.auth as AuthContext;
 
   // Authenticate using default guard
@@ -89,7 +89,7 @@ app.get("/profile", (ctx) => {
   return { user: auth.user() };
 });
 
-app.listen(3000);
+app.listen({ port: 3000 });
 ```
 
 Benefits: no global singleton, multiple apps can have different auth configs, auth context is attached per request, type-safe access via `ctx.locals.auth`.


### PR DESCRIPTION
Per-package docs cleanup (documentation #17). README = short landing + link; docs/index.md = canonical full reference. No version change.