### PR TITLE
ci: add release tag workflow on merge to main

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,49 @@
+name: Tag release on main
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: tag-release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get and validate version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [ -z "$VERSION" ]; then
+            echo "::error::package.json version is empty"
+            exit 1
+          fi
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'; then
+            echo "::error::Invalid semver format: $VERSION. Expected x.y.z or x.y.z-prerelease"
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag already exists
+        run: |
+          TAG="v${{ steps.version.outputs.VERSION }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists. Bump the version in package.json before merging."
+            exit 1
+          fi
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          TAG="v${{ steps.version.outputs.VERSION }}"
+          git tag "$TAG" ${{ github.sha }}
+          git push origin "$TAG"

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -18,10 +18,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: oven-sh/setup-bun@v2
+
       - name: Get and validate version from package.json
         id: version
         run: |
-          VERSION=$(node -p "require('./package.json').version")
+          VERSION=$(bun -p "require('./package.json').version")
           if [ -z "$VERSION" ]; then
             echo "::error::package.json version is empty"
             exit 1


### PR DESCRIPTION
Closes #34
Closes bunary-dev/.github#5

## Summary

Add GitHub workflow that creates a git tag when changes are merged to main. Based on validated workflow from bunary-dev/examples#28.

## Workflow behavior

- **Trigger:** Push to main
- **Version validation:** Semver format (x.y.z or x.y.z-prerelease)
- **Tag exists check:** Fails if tag already exists — enforces version bump discipline
- **No force push:** Normal tag push only
- **Concurrency:** One run at a time to avoid races on rapid merges