### PR TITLE
chore: release 0.1.0 - first minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2026-01-31
+
+### Added
+
+- First minor release — API stable for production use
+
 ## [0.0.7] - 2026-01-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- First minor release — API stable for production use
+- First minor release — API stable for development use until 1.0.0
 
 ## [0.0.7] - 2026-01-29
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunary/auth",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Authentication guards and helpers for Bunary - a Bun-first backend framework inspired by Laravel",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Closes #33

## Changes
- Bump version to 0.1.0
- Update CHANGELOG: first minor release — API stable for production use
- No dependencies to update